### PR TITLE
fix: change storage encryption default to true

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -108,7 +108,7 @@ variable "max_allocated_storage" {
 variable "storage_encrypted" {
   description = "Specifies whether the DB instance is encrypted"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "kms_key_id" {


### PR DESCRIPTION
follow security compliance best practice, data should always be encrypted.

# Submit a pull request :rocket:

Thank you for help us contribute! Please give us more information about this PR.

---
## What :kissing:
### Adds

### Fixes
- Resouces RDS encryption

### Changes
- Changes var `storage_encrypted` default value from false to true

## Why :pleading_face:
- Follow the security compliance best practice, all the data should be encrypted by default. 


## Other Info
